### PR TITLE
Feature/add sleep data for display

### DIFF
--- a/src/AllTimeHydration.js
+++ b/src/AllTimeHydration.js
@@ -29,15 +29,14 @@ class AllTimeHydration {
   }
 
   getWeeklyHydration(date) {
-    if (this.individualHydration.length <= 7) {
-      return this.individualHydration;
-    } else {
-      const i = this.individualHydration.findIndex(
-        (element) => element.date === date
-      );
-      ///need to change test to pass new logic below
-      return this.individualHydration.slice(i - 6, i + 1);
+    const i = this.individualHydration.findIndex(
+      (element) => element.date === date
+    );
+
+    if (i < 7) {
+      return this.individualHydration.slice(0, i + 1);
     }
+    return this.individualHydration.slice(i - 6, i + 1);
   }
 }
 

--- a/src/SleepRepository.js
+++ b/src/SleepRepository.js
@@ -32,12 +32,13 @@ class SleepRepository {
     return Number((totaled / this.individualsSleep.length).toFixed(1));
   }
 
-  getSevenDays(date, property) {
-    const dateIndex = this.individualsSleep.findIndex(
-      (sleep) => sleep.date === date
-    );
-    const sevenDays = this.individualsSleep.slice(dateIndex, dateIndex + 7);
-    return sevenDays.map((sleep) => sleep[property]);
+  getSevenDays(date) {
+    const i = this.individualsSleep.findIndex((sleep) => sleep.date === date);
+
+    if (i < 7) {
+      return this.individualsSleep.slice(0, i + 1);
+    }
+    return this.individualsSleep.slice(i - 6, i + 1);
   }
 
   getAvgSleepForAll() {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -65,8 +65,8 @@ function loadUserData() {
     displayProfileBox(); //DOM
     displayDailyHydration('2020/01/22');
     displayWeeklyHydration('2020/01/22');
-    displayDailySleepStats('2019/06/15');
-    //displayWeeklySleep('2019/06/15')
+    displayDailySleepStats('2020/01/19');
+    displayWeeklySleep('2020/01/19');
   });
 }
 
@@ -93,7 +93,7 @@ function instantiateSleep(parsedData, user) {
   sleepStats.getIndividualsSleep(user);
 }
 
-//
+/* REPORTS */
 
 function reportDailyHydration(date) {
   const day = hydrationStats.individualHydration.find(
@@ -104,10 +104,6 @@ function reportDailyHydration(date) {
   return { ounces: day.numOunces, average: avg };
 }
 
-// function reportWeeklyHydration(date) {
-//   return hydrationStats.getWeeklyHydration(date);
-// }
-
 function reportNightlySleep(date, property) {
   const night = sleepStats.individualsSleep.find(
     (sleep) => sleep.date === date
@@ -117,9 +113,16 @@ function reportNightlySleep(date, property) {
   return { date: date, value: night[property], average: avg };
 }
 
-function reportWeeksSleep(date) {}
+function reportWeeklySleep(date, property) {
+  const week = sleepStats.getSevenDays(date);
+  const weeksSleep = week.map((day) => {
+    return { date: day.date, [property]: day[property] };
+  });
 
-/* DOM Manipulation */
+  return weeksSleep;
+}
+
+/* DOM  */
 function displayProfileBox() {
   userGreeting.innerText = currentUser.getFirstName();
   address.innerText = currentUser.address;
@@ -141,24 +144,28 @@ function displayWeeklyHydration(date) {
   makeWeeklyHydrationChart(report);
 }
 
-/* ---------- */
 function displayDailySleepStats(date) {
   // will make to report objects using reportNightlySleep()
   const hoursSlept = reportNightlySleep(date, 'hoursSlept');
   const sleepQuality = reportNightlySleep(date, 'sleepQuality');
 
-  console.log(hoursSlept); //remove after chart added
-  console.log(sleepQuality);
-  //make 2 charts
-  //one for night's sleep vs avg // makeNightsSleepChart(hoursSlept);
-  //one for night's score vs avg  // makeNightsQualityChart(sleepQuality)
+  console.log('hoursSlept', hoursSlept); //remove after chart
+  console.log('sleepQuality', sleepQuality);
+
+  //sleep vs avg // makeNightsSleepChart(hoursSlept);
+  //score vs avg  // makeNightsQualityChart(sleepQuality)
 }
 
 function displayWeeklySleep(date) {
-  // will use the getSevenDays method to
+  const week = reportWeeklySleep(date, 'hoursSlept');
+  console.log('7 sleep objects', week); //remove after chart is added
+
+  //chart of week's sleep //makeWeeksSleepChart()
 }
 
 // Charts!!
 function makeNightsSleepChart() {}
 
 function makeNigthsQualityChart() {}
+
+function makeWeeksSleepChart() {}

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -61,9 +61,12 @@ function loadUserData() {
     getCurrentUser(data[0].userData, userID);
     instantiateHydration(data[1].hydrationData, userID);
     instantiateSleep(data[2].sleepData, userID);
+
     displayProfileBox(); //DOM
     displayDailyHydration('2020/01/22');
     displayWeeklyHydration('2020/01/22');
+    displayDailySleepStats('2019/06/15');
+    //displayWeeklySleep('2019/06/15')
   });
 }
 
@@ -72,7 +75,7 @@ function getRandomUser(userArray) {
   return Math.ceil(Math.random() * numOfUsers);
 }
 
-//
+/* INSTANTIATIONS */
 
 function getCurrentUser(parsedData, user) {
   userRepo = new UserRepository(parsedData);
@@ -101,22 +104,22 @@ function reportDailyHydration(date) {
   return { ounces: day.numOunces, average: avg };
 }
 
-function reportWeeklyHydration(date) {
-  return hydrationStats.getWeeklyHydration(date);
+// function reportWeeklyHydration(date) {
+//   return hydrationStats.getWeeklyHydration(date);
+// }
+
+function reportNightlySleep(date, property) {
+  const night = sleepStats.individualsSleep.find(
+    (sleep) => sleep.date === date
+  );
+  const avg = sleepStats.calculateAvg(property);
+
+  return { date: date, value: night[property], average: avg };
 }
 
-// DOM manipulation functions
+function reportWeeksSleep(date) {}
 
-// function displayDailyHydration(date) {
-//   const report = reportDailyHydration(date);
-//   dailyWater.innerText = `Date: ${date} Ounces: ${report.ounces} Average: ${report.average}`;
-// }
-
-// function displayWeeklyHydration(date) {
-//   const report = reportWeeklyHydration(date);
-//   weeklyWater.innerText = JSON.stringify(report);
-// }
-
+/* DOM Manipulation */
 function displayProfileBox() {
   userGreeting.innerText = currentUser.getFirstName();
   address.innerText = currentUser.address;
@@ -134,6 +137,28 @@ function displayDailyHydration(date) {
 }
 
 function displayWeeklyHydration(date) {
-  const report = reportWeeklyHydration(date);
+  const report = hydrationStats.getWeeklyHydration(date);
   makeWeeklyHydrationChart(report);
 }
+
+/* ---------- */
+function displayDailySleepStats(date) {
+  // will make to report objects using reportNightlySleep()
+  const hoursSlept = reportNightlySleep(date, 'hoursSlept');
+  const sleepQuality = reportNightlySleep(date, 'sleepQuality');
+
+  console.log(hoursSlept); //remove after chart added
+  console.log(sleepQuality);
+  //make 2 charts
+  //one for night's sleep vs avg // makeNightsSleepChart(hoursSlept);
+  //one for night's score vs avg  // makeNightsQualityChart(sleepQuality)
+}
+
+function displayWeeklySleep(date) {
+  // will use the getSevenDays method to
+}
+
+// Charts!!
+function makeNightsSleepChart() {}
+
+function makeNigthsQualityChart() {}

--- a/test/AllTimeHydration-test.js
+++ b/test/AllTimeHydration-test.js
@@ -40,7 +40,7 @@ describe('AllTimeHydration', () => {
 
   it("should start with an array of all user's hydration data", () => {
     expect(allTimeHydration.allUsersHydration).to.be.a('array');
-    expect(allTimeHydration.allUsersHydration[7].numOunces).to.equal(28);
+    expect(allTimeHydration.allUsersHydration[7].numOunces).to.equal(30);
   });
 
   it('should start with an empty individual user hydration array', () => {
@@ -87,8 +87,8 @@ describe('AllTimeHydration', () => {
 
     expect(weeksHydration[1]).to.deep.equal({
       id: 2,
-      date: '2019/06/13',
-      numOunces: 100,
+      date: '2019/06/09',
+      numOunces: 20,
     });
   });
 
@@ -124,7 +124,7 @@ describe('AllTimeHydration', () => {
     allTimeHydration.getIndividualHydration(1);
 
     const lessThanWeekHydration =
-      allTimeHydration.getWeeklyHydration('2019/06/14');
+      allTimeHydration.getWeeklyHydration('2019/06/13');
 
     expect(lessThanWeekHydration).to.deep.equal([
       {
@@ -151,6 +151,6 @@ describe('AllTimeHydration', () => {
     const lessThanWeekHydration =
       allTimeHydration.getWeeklyHydration('2019/06/08');
 
-    expect(lessThanWeekHydration[1].numOunces).to.deep.equal(87);
+    expect(lessThanWeekHydration[1].numOunces).to.deep.equal(36);
   });
 });

--- a/test/SleepRepository-test.js
+++ b/test/SleepRepository-test.js
@@ -8,22 +8,22 @@ describe('SleepRepository', () => {
 
   beforeEach(() => {
     allSleepData = [
-      { userID: 1, date: '2019/06/15', hoursSlept: 6.1, sleepQuality: 2.2 },
-      { userID: 2, date: '2019/06/15', hoursSlept: 7, sleepQuality: 4.7 },
-      { userID: 1, date: '2019/06/14', hoursSlept: 10.8, sleepQuality: 4.7 },
-      { userID: 2, date: '2019/06/14', hoursSlept: 5.4, sleepQuality: 3 },
-      { userID: 1, date: '2019/06/13', hoursSlept: 4.1, sleepQuality: 3.6 },
-      { userID: 2, date: '2019/06/13', hoursSlept: 9.6, sleepQuality: 2.9 },
-      { userID: 1, date: '2019/06/12', hoursSlept: 5.7, sleepQuality: 2.4 },
-      { userID: 2, date: '2019/06/12', hoursSlept: 5, sleepQuality: 3.6 },
-      { userID: 1, date: '2019/06/11', hoursSlept: 6.6, sleepQuality: 4.4 },
-      { userID: 2, date: '2019/06/11', hoursSlept: 9.5, sleepQuality: 4.2 },
-      { userID: 1, date: '2019/06/10', hoursSlept: 9.4, sleepQuality: 4.4 },
-      { userID: 2, date: '2019/06/10', hoursSlept: 7.5, sleepQuality: 4.7 },
-      { userID: 1, date: '2019/06/09', hoursSlept: 5, sleepQuality: 2.5 },
-      { userID: 2, date: '2019/06/09', hoursSlept: 10.1, sleepQuality: 4.7 },
-      { userID: 1, date: '2019/06/08', hoursSlept: 5, sleepQuality: 3.6 },
       { userID: 2, date: '2019/06/08', hoursSlept: 6.6, sleepQuality: 4.4 },
+      { userID: 1, date: '2019/06/08', hoursSlept: 5, sleepQuality: 3.6 },
+      { userID: 2, date: '2019/06/09', hoursSlept: 10.1, sleepQuality: 4.7 },
+      { userID: 1, date: '2019/06/09', hoursSlept: 5, sleepQuality: 2.5 },
+      { userID: 2, date: '2019/06/10', hoursSlept: 7.5, sleepQuality: 4.7 },
+      { userID: 1, date: '2019/06/10', hoursSlept: 9.4, sleepQuality: 4.4 },
+      { userID: 2, date: '2019/06/11', hoursSlept: 9.5, sleepQuality: 4.2 },
+      { userID: 1, date: '2019/06/11', hoursSlept: 6.6, sleepQuality: 4.4 },
+      { userID: 2, date: '2019/06/12', hoursSlept: 5, sleepQuality: 3.6 },
+      { userID: 1, date: '2019/06/12', hoursSlept: 5.7, sleepQuality: 2.4 },
+      { userID: 2, date: '2019/06/13', hoursSlept: 9.6, sleepQuality: 2.9 },
+      { userID: 1, date: '2019/06/13', hoursSlept: 4.1, sleepQuality: 3.6 },
+      { userID: 2, date: '2019/06/14', hoursSlept: 5.4, sleepQuality: 3 },
+      { userID: 1, date: '2019/06/14', hoursSlept: 10.8, sleepQuality: 4.7 },
+      { userID: 2, date: '2019/06/15', hoursSlept: 7, sleepQuality: 4.7 },
+      { userID: 1, date: '2019/06/15', hoursSlept: 6.1, sleepQuality: 2.2 },
     ];
 
     sleepRepo = new SleepRepository(allSleepData);
@@ -83,36 +83,34 @@ describe('SleepRepository', () => {
     expect(avgScore).to.equal(3.5);
   });
 
-  it("should be able to return a week's worth of hours slept", () => {
+  it("should be able to return a week's worth of data", () => {
     sleepRepo.getIndividualsSleep(1);
 
-    const weekOfSleep = sleepRepo.getSevenDays('2019/06/15', 'hoursSlept');
+    const weekOfSleep = sleepRepo.getSevenDays('2019/06/15');
 
-    expect(weekOfSleep).to.deep.equal([6.1, 10.8, 4.1, 5.7, 6.6, 9.4, 5]);
+    expect(weekOfSleep[0]).to.deep.equal({
+      id: 1,
+      date: '2019/06/09',
+      hoursSlept: 5,
+      sleepQuality: 2.5,
+    });
+    expect(weekOfSleep.length).to.equal(7);
   });
 
   it('should be able to handle an incomplete data for a selected 7 days', () => {
     sleepRepo.getIndividualsSleep(1);
 
-    const lessThanAWeek = sleepRepo.getSevenDays('2019/06/10', 'hoursSlept');
+    const lessThanAWeek = sleepRepo.getSevenDays('2019/06/10');
 
-    expect(lessThanAWeek).to.deep.equal([9.4, 5, 5]);
-  });
-
-  it("should be able to return a week's worth of sleep quality scores", () => {
-    sleepRepo.getIndividualsSleep(1);
-
-    const weekOfScores = sleepRepo.getSevenDays('2019/06/15', 'sleepQuality');
-
-    expect(weekOfScores).to.deep.equal([2.2, 4.7, 3.6, 2.4, 4.4, 4.4, 2.5]);
-  });
-
-  it('should be able to handle an incomplete data for a selected 7 days', () => {
-    sleepRepo.getIndividualsSleep(1);
-
-    const lessThanAWeek = sleepRepo.getSevenDays('2019/06/10', 'sleepQuality');
-
-    expect(lessThanAWeek).to.deep.equal([4.4, 2.5, 3.6]);
+    expect(lessThanAWeek[0]).to.deep.equal({
+      id: 1,
+      date: '2019/06/08',
+      hoursSlept: 5,
+      sleepQuality: 3.6,
+    });
+    console.log(lessThanAWeek);
+    console.log('length', lessThanAWeek.length);
+    expect(lessThanAWeek.length).to.equal(3);
   });
 
   it('should be able to return the average sleep quality of all user over all time', () => {


### PR DESCRIPTION
### Description
Make minor corrections to the AllTimeHydration and SleepRepository weekly data methods, and their respective test files to fix a API data order issue. Adds the daily and weekly sleep data set-up to scripts so that it can used to make charts. 

#### Type of change
- [x] Bug fix
- [X] New feature
- [ ] New feature that breaks previous code

#### How Has This Been Tested?
- [X] dev tools
- [X] run local:8080
- [X] console.log()

#### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

#### Additional Comments:
Close #18
Close #24 